### PR TITLE
Enable a bot character escape for identifying commands

### DIFF
--- a/service/bot.go
+++ b/service/bot.go
@@ -1,9 +1,12 @@
 package service
 
 import (
+	"errors"
 	dgo "github.com/bwmarrin/discordgo"
 	"github.com/sirupsen/logrus"
 )
+
+var ErrNotCommand = errors.New("message content is not a command")
 
 // `Config` is the configuration for the bot.
 type Config struct {

--- a/service/message-handler.go
+++ b/service/message-handler.go
@@ -8,12 +8,15 @@ import (
 // In particular, it creates a category with every channel specified
 // in the configuration file of the bot.
 func (bot *_bot) MessageHandler(session *discordgo.Session, message *discordgo.MessageCreate) {
-	content := message.Content
-
-	// TODO: add a ! check at the beginning of the message
 	// If the message was sent to a channel different from the one used for categories creation
 	// or if the author of the message was the bot itself
 	if message.ChannelID != bot.buildChannelID || message.Author.ID == session.State.User.ID {
+		return
+	}
+	// Check whether the content of the message has the correct starting character
+	content, err := bot.SanitizeCommand(message.Content)
+	if err == ErrNotCommand {
+		bot.log.WithError(err).WithField("userID", message.Author).Error("Not a command meant for the bot.")
 		return
 	}
 

--- a/service/sanitize-command.go
+++ b/service/sanitize-command.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"strings"
+	"text/scanner"
+)
+
+// `SanitizeCommand` takes the content of the received message and scans it.
+// If it starts with the correct beginning character `!`, it is a good command.
+// Otherwise, it is a command not meant for the bot.
+// It takes as input the content of the message and returns the proper command
+// and an error, if any.
+func (bot *_bot) SanitizeCommand(content string) (string, error) {
+	var stringScan scanner.Scanner
+
+	// Initialize the string scanner for the content string
+	stringScan.Init(strings.NewReader(content))
+
+	// Scan the next token. It should be the character `!`.
+	// Then convert the scanned token to a string.
+	_ = stringScan.Scan()
+	commandIdentifier := stringScan.TokenText()
+
+	// If the token was not the correct character, return
+	if commandIdentifier != "!" {
+		bot.log.Warn("Message not meant to be a command for the bot.")
+		return "", ErrNotCommand
+	}
+
+	// Scan the next token. It should be the command itself.
+	_ = stringScan.Scan()
+	command := stringScan.TokenText()
+	return command, nil
+}


### PR DESCRIPTION
Previously, the bot accepted every command without checking if it was really meant for it or not. Something like golang should not be accepted because someone could have no intention in talking to the bot. Now, bot is triggered if someone writes !golang.